### PR TITLE
#CP-18 chore: heroku postgres provisioning and configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node ./src/app.js

--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,9 @@ import indexRouter from './routes/indexRouter.js';
 const swaggerSpec = swaggerJSDoc(options);
 const __dirname = path.resolve();
 
+/* c8 ignore start */
 const PORT = process.env.PORT || 5000;
+/* c8 ignore next stop */
 const app = express();
 app.use(cors());
 app.use(reqLogger);
@@ -44,6 +46,7 @@ AppDataSource.initialize()
 		});
 	})
 	.catch((error) => {
+		/* c8 ignore next 5 */
 		logger.error(error.message);
 		logger.error(
 			"The server couldn't be started. The database is not connected"

--- a/src/data-source.js
+++ b/src/data-source.js
@@ -1,8 +1,9 @@
+/* eslint-disable */
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
 import { UserSchema } from './models/user.js';
 
-export const AppDataSource = new DataSource({
+let options = {
 	type: 'postgres',
 	host: process.env.DB_HOST,
 	port: process.env.DB_PORT,
@@ -10,7 +11,6 @@ export const AppDataSource = new DataSource({
 	password: process.env.DB_PASS,
 	database: process.env.DB,
 	synchronize: true,
-
 	logging: false,
 	entities: [UserSchema],
 	migrations: ['./migration/*.js'],
@@ -18,6 +18,19 @@ export const AppDataSource = new DataSource({
 	cli: {
 		migrationsDir: './migration/',
 	},
-});
+};
+
+/* c8 ignore start  */
+if (process.env.NODE_ENV === 'production') {
+	Object.assign(options, {
+		extra: {
+			ssl: {
+				rejectUnauthorized: false,
+			},
+		},
+	});
+}
+/* c8 ignore */
+export const AppDataSource = new DataSource(options);
 
 export default AppDataSource;


### PR DESCRIPTION
### What this PR does:
This PR fix the issue of changing the whole settings to use Heroku Postgres
This adds:
- [ ] Heroku PostgreSQL Provisioning
- [ ] Heroku PostgreSQL configuration

### Background context:
- Deployment on Heroku and use of Heroku provisioned PostgreSQL database require **SSL** for authentication. 
> Since development database server only accept the **HTTP**, the issue was being raised on Heroku about the connection.
To solve such challenge, a new option entry is added when the environment is set to production which is the default on Heroku. The setting set SSL in the **extra options** and since we are not using the certificate, we are setting the flag to accept **self-signed certificate** by setting the **rejectUnauthorized** option to false.

- **Lint ignore flag** has been added to the file since the entry is being added with **Object.assign()** method and the lint was not recognizing the **re-assignment**.

- Apart from that the lines in the app that logged the error message has been added to the test-coverage report ignore lists since they can not be hit in **Continuous integration tests**. Not to be abused, the ignore is used to handle some impossible instance you can't test. **[Check this block for more information.](https://github.com/bcoe/c8/blob/main/README.md#:~:text=wanting%20to%20ignore%20uncovered)**

### How can this be manually tested
Since the changes affect the server side deployment, the project is expected to run normally as usual. A proof of working concept can be [found on this link where the same code](https://phantom-codebandits.herokuapp.com/) is running compared to the one on our staging site [which break on start](https://phantom-be-codebandits-staging.herokuapp.com/).
Finishes [#CP18]