### PR TITLE
#CP-9 feat: roles and permissions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-
 npm run lint-fix
 npx lint-staged
 git add .

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,5 +15,7 @@
 	"user does not exist": "user does not exist",
 	"wrong email or password": "wrong email or password",
 	"you need to login first": "you need to login first",
-	"Server error": "Server error"
+	"Server error": "Server error",
+	"Unauthorized": "Unauthorized access",
+	"Password or email is invalid": "Password or email is invalid"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -14,5 +14,7 @@
 	"user_conflict": "L'utilisateur avec cet email existe",
 	"user does not exist": "l'utilisateur n'existe pas",
 	"wrong email or password": "mauvais email ou password",
-	"you need to login first": "tu dois d'abord te connecter"
+	"you need to login first": "tu dois d'abord te connecter",
+	"Unauthorized": "L'accès non autorisé",
+	"Password or email is invalid": "Le mot de passe ou l'e-mail est invalide"
 }

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -15,5 +15,7 @@
 	"user does not exist": "iyi konti ntayihari",
 	"wrong email or password": "mwibeshye imeri cyangwa umubare w'ibanga",
 	"you need to login first": "ugomba kubanza kwinjira",
-	"Server error": "Server error"
+	"Server error": "Server error",
+	"Unauthorized": "Nta burenganzira ubifitiye",
+	"Password or email is invalid": "Ijambo banga cyangwa imeri ntabwo byemewe"
 }

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import 'reflect-metadata';
+import { UserSchema } from './src/models/user.js';
+
+export default {
+	type: 'postgres',
+	host: process.env.DB_HOST,
+	port: process.env.DB_PORT,
+	username: process.env.DB_USER,
+	password: process.env.DB_PASS,
+	database: process.env.DB,
+	synchronize: false,
+	logging: false,
+	entities: [UserSchema],
+	migrations: [path.join(path.resolve(), 'src/migration/*.js')],
+	subscribers: [],
+	cli: {
+		migrationsDir: path.join(path.resolve(), 'src/migration/'),
+	},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"accesscontrol": "^2.2.1",
 				"bcrypt": "^5.0.1",
 				"body-parser": "^1.19.2",
 				"c8": "^7.11.0",
@@ -974,6 +975,14 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accesscontrol": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/accesscontrol/-/accesscontrol-2.2.1.tgz",
+			"integrity": "sha512-52EvFk/J9EF+w4mYQoKnOTkEMj01R1U5n2fc1dai6x1xkgOks3DGkx01qQL2cKFxGmE4Tn1krAU3jJA9L1NMkg==",
+			"dependencies": {
+				"notation": "^1.3.6"
 			}
 		},
 		"node_modules/acorn": {
@@ -6160,6 +6169,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/notation": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/notation/-/notation-1.3.6.tgz",
+			"integrity": "sha512-DIuJmrP/Gg1DcXKaApsqcjsJD6jEccqKSfmU3BUx/f1GHsMiTJh70cERwYc64tOmTRTARCeMwkqNNzjh3AHhiw=="
+		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -10147,6 +10161,14 @@
 				"negotiator": "0.6.3"
 			}
 		},
+		"accesscontrol": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/accesscontrol/-/accesscontrol-2.2.1.tgz",
+			"integrity": "sha512-52EvFk/J9EF+w4mYQoKnOTkEMj01R1U5n2fc1dai6x1xkgOks3DGkx01qQL2cKFxGmE4Tn1krAU3jJA9L1NMkg==",
+			"requires": {
+				"notation": "^1.3.6"
+			}
+		},
 		"acorn": {
 			"version": "8.7.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -14058,6 +14080,11 @@
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
 			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+		},
+		"notation": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/notation/-/notation-1.3.6.tgz",
+			"integrity": "sha512-DIuJmrP/Gg1DcXKaApsqcjsJD6jEccqKSfmU3BUx/f1GHsMiTJh70cERwYc64tOmTRTARCeMwkqNNzjh3AHhiw=="
 		},
 		"npm-run-path": {
 			"version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"prepare": "husky install",
 		"start": "node src/app.js",
 		"dev": "nodemon src/app.js",
-		"lint": "eslint \"**/*.js\" --max-warnings=0",
+		"lint": "eslint \"**/*.js\" --fix --max-warnings=0",
 		"format": "prettier --write ./**/*.{js,jsx,json}",
 		"lint-fix": "eslint \"**/*.js\" --fix"
 	},
@@ -46,6 +46,7 @@
 	},
 	"dependencies": {
 		"bcrypt": "^5.0.1",
+		"accesscontrol": "^2.2.1",
 		"body-parser": "^1.19.2",
 		"c8": "^7.11.0",
 		"chai-http": "^4.3.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,10 @@
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import 'dotenv/config';
 import express from 'express';
 import path from 'path';
 import swaggerJSDoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
-import cookieParser from 'cookie-parser';
 import i18n from './configs/i18n.js';
 import reqLogger from './configs/reqLogger.js';
 import options, { customizationOptions } from './configs/swagger.js';
@@ -12,6 +12,7 @@ import logger from './configs/winston.js';
 import { AppDataSource } from './data-source.js';
 import apiRouter from './routes/apiRouter.js';
 import indexRouter from './routes/indexRouter.js';
+import errLogger from './utils/errorLogger.js';
 
 const swaggerSpec = swaggerJSDoc(options);
 const __dirname = path.resolve();
@@ -36,6 +37,7 @@ app.use(
 
 app.use('/api/v1', apiRouter);
 app.use('/', indexRouter);
+app.use(errLogger);
 AppDataSource.initialize()
 	.then(async () => {
 		logger.info('Postgres database connected');

--- a/src/configs/ac.js
+++ b/src/configs/ac.js
@@ -1,0 +1,12 @@
+import { AccessControl } from 'accesscontrol';
+import grants from './grants.js';
+// TODO Replace the object with database models
+
+const accesscontrol = new AccessControl();
+
+accesscontrol.setGrants(grants);
+accesscontrol.grant('driver').extend(['user']);
+accesscontrol.grant('operator').extend(['user', 'driver']);
+accesscontrol.grant('admin').extend(['driver', 'user', 'operator']);
+
+export default accesscontrol;

--- a/src/configs/grants.js
+++ b/src/configs/grants.js
@@ -1,0 +1,45 @@
+export default {
+	user: {
+		drivers: {
+			'read:any': ['*', '!email', '!password', '!id', '!role'],
+		},
+	},
+	driver: {
+		drivers: {
+			'read:own': ['*'],
+			'update:own': ['*', '!email', '!password'],
+		},
+		buses: {
+			'update:own': ['*'],
+		},
+		profiles: {
+			'update:own': ['*', '!email', '!password'],
+		},
+	},
+
+	operator: {
+		routes: {
+			'create:any': ['*'],
+			'read:any': ['*'],
+			'update:any': ['*'],
+			'delete:any': ['*'],
+		},
+		drivers: {
+			'create:any': ['*'],
+			'read:any': ['*'],
+			'update:any': ['*'],
+			'delete:any': ['*'],
+		},
+		buses: {
+			'create:any': ['*'],
+			'read:any': ['*'],
+			'update:any': ['*'],
+			'delete:any': ['*'],
+		},
+	},
+	admin: {
+		companies: {
+			'create:any': ['*'],
+		},
+	},
+};

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -8,7 +8,9 @@ import handleResponse from './handleResponse.js';
 const AuthHandler = async (req, res) => {
 	const user = await User.findOneBy({ email: req.body.email });
 	if (!user) {
-		return handleResponse(res, 404, { message: res.__('user does not exist') });
+		return handleResponse(res, 400, {
+			message: res.__('Password or email is invalid'),
+		});
 	}
 	try {
 		if (await bcrypt.compare(req.body.password, user.password)) {
@@ -30,8 +32,8 @@ const AuthHandler = async (req, res) => {
 				access_token: accessToken,
 			});
 		}
-		return handleResponse(res, 401, {
-			message: res.__('wrong email or password'),
+		return handleResponse(res, 400, {
+			message: res.__('Password or email is invalid'),
 		});
 		/* c8 ignore next 3 */
 	} catch (err) {

--- a/src/controllers/tests/auth.test.js
+++ b/src/controllers/tests/auth.test.js
@@ -32,7 +32,7 @@ describe('LOGIN', () => {
 					firstName: 'Patrick',
 					lastName: 'Shema',
 					email: 'patrickshema@gmail.com',
-					password: 'patrickshema',
+					password: 'Andela@123',
 					role: 'admin',
 				})
 				.end((err, res) => {
@@ -42,7 +42,7 @@ describe('LOGIN', () => {
 						.post('/api/v1/accounts/login')
 						.send({
 							email: 'patrickshema@gmail.com',
-							password: 'patrickshema',
+							password: 'Andela@123',
 						})
 						.end((err, res) => {
 							res.should.have.status(200);
@@ -61,7 +61,7 @@ describe('LOGIN', () => {
 				.post('/api/v1/accounts/login')
 				.send({
 					email: 'patrickshema@gmail.com',
-					password: 'patrickshema',
+					password: 'Andela@123',
 				})
 				.end((err, res) => {
 					res.should.have.status(200);
@@ -82,7 +82,7 @@ describe('LOGIN', () => {
 					password: 'ericngabo',
 				})
 				.end((err, res) => {
-					res.should.have.status(404);
+					res.should.have.status(400);
 					res.body.should.be.a('object');
 					res.body.should.have.property('data');
 					res.body.data.should.have.property('message');
@@ -100,7 +100,7 @@ describe('LOGIN', () => {
 					password: 'ericngabo',
 				})
 				.end((err, res) => {
-					res.should.have.status(401);
+					res.should.have.status(400);
 					res.body.should.be.a('object');
 					res.body.should.have.property('data');
 					res.body.data.should.have.property('message');

--- a/src/controllers/tests/refreshToken.test.js
+++ b/src/controllers/tests/refreshToken.test.js
@@ -29,7 +29,7 @@ describe('REFRESH', () => {
 					firstName: 'Patrick',
 					lastName: 'Shema',
 					email: 'patrickshema@gmail.com',
-					password: 'patrickshema',
+					password: 'Andela@123',
 					role: 'admin',
 				})
 				.end((err, res) => {
@@ -39,7 +39,7 @@ describe('REFRESH', () => {
 						.post('/api/v1/accounts/login')
 						.send({
 							email: 'patrickshema@gmail.com',
-							password: 'patrickshema',
+							password: 'Andela@123',
 						})
 						.end((err, res) => {
 							res.should.have.status(200);

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,22 +1,18 @@
-import bcrypt from 'bcrypt';
+import { AccessControl } from 'accesscontrol';
 import { User } from '../models/user.js';
 import handleResponse from './handleResponse.js';
 import saveUser from './services/saveUser.js';
 
-export const GetUsers = async (_, res) => {
+export const GetUsers = async (req, res) => {
 	const users = await User.find();
-	return handleResponse(res, 200, users);
+	return handleResponse(res, 200, AccessControl.filter(users, req.attributes));
 };
 
 export const CreateUser = async (req, res) => {
-	const hashedPassword = await bcrypt.hash(req.body.password, 10);
-	const user = await User.findOneBy({ email: req.body.email });
-	if (user) return handleResponse(res, 409, res.__('user_conflict'));
-	try {
-		req.body.password = hashedPassword;
-		const newUser = await saveUser(req.body);
-		return handleResponse(res, 201, newUser);
-	} catch (error) {
-		return handleResponse(res, 400, { message: res.__('bad_data') });
-	}
+	const newUser = await saveUser(req.body);
+	const { password, ...data } = newUser;
+	return handleResponse(res, 201, data);
 };
+
+export const testPermissionUser = async (req, res) =>
+	handleResponse(res, 200, 'Getting user');

--- a/src/middlewares/CheckPermission.js
+++ b/src/middlewares/CheckPermission.js
@@ -1,0 +1,79 @@
+import ac from '../configs/ac.js';
+import handleResponse from '../controllers/handleResponse.js';
+
+const CheckPermissionAny = (resource) => async (req, res, next) => {
+	if (req.user.role === 'admin') return next();
+	let permission;
+	switch (req.method) {
+		case 'GET':
+			permission = ac.can(req.user.role).readAny(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+		case 'POST':
+			permission = ac.can(req.user.role).createAny(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+		case 'PUT':
+			permission = ac.can(req.user.role).updateAny(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+		case 'DELETE':
+			permission = ac.can(req.user.role).deleteAny(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+
+		default:
+			return handleResponse(res, 403, 'Permission denied');
+	}
+};
+export default CheckPermissionAny;
+
+export const CheckPermissionOwn = (resource) => async (req, res, next) => {
+	if (req.user.role === 'admin') return next();
+	let permission;
+	switch (req.method) {
+		case 'GET':
+			permission = ac.can(req.user.role).readOwn(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+		case 'POST':
+			permission = ac.can(req.user.role).createOwn(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+		case 'PUT':
+			permission = ac.can(req.user.role).updateOwn(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+		case 'DELETE':
+			permission = ac.can(req.user.role).deleteOwn(resource);
+			if (permission.granted) {
+				req.attributes = permission.attributes;
+				return next();
+			}
+			return handleResponse(res, 401, res.__('Unauthorized'));
+
+		default:
+			return handleResponse(res, 403, 'Permission denied');
+	}
+};

--- a/src/middlewares/VerifyJWT.js
+++ b/src/middlewares/VerifyJWT.js
@@ -1,0 +1,9 @@
+const verifyJWT = (role) => async (req, res, next) => {
+	req.user = {
+		name: 'fabrice',
+		role: role || 'driver',
+	};
+	next();
+};
+
+export default verifyJWT;

--- a/src/middlewares/authJwt.js
+++ b/src/middlewares/authJwt.js
@@ -1,5 +1,5 @@
-import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
 
 dotenv.config();
 
@@ -10,7 +10,7 @@ const verifyToken = (req, res, next) => {
 		return res.status(401).send({
 			status: 'fail',
 			code: 401,
-			message: 'Unauthorized',
+			message: 'Unauthorized with token',
 		});
 
 	jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, (err, user) => {

--- a/src/models/Permission.js
+++ b/src/models/Permission.js
@@ -1,0 +1,13 @@
+import { BaseEntity } from 'typeorm';
+
+class Permission extends BaseEntity {
+	id;
+
+	resource;
+
+	action;
+
+	attributes;
+}
+
+export default Permission;

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -1,0 +1,11 @@
+import { BaseEntity } from 'typeorm';
+
+class Role extends BaseEntity {
+	id;
+
+	name;
+
+	permissions;
+}
+
+export default Role;

--- a/src/rolesApp/controller.js
+++ b/src/rolesApp/controller.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+
+export const raiseError = async (req, res, next) => {
+	throw new Error('Checking');
+};
+
+export default raiseError;

--- a/src/rolesApp/validation.js
+++ b/src/rolesApp/validation.js
@@ -1,0 +1,36 @@
+import bcrypt from 'bcrypt';
+import { body, validationResult } from 'express-validator';
+import User from '../models/user.js';
+
+export const createUserValidation = () => [
+	body('email', 'A valid email required')
+		.notEmpty()
+		.isEmail()
+		.normalizeEmail()
+		.bail()
+		.custom(async (email) => {
+			const user = await User.findOne({ where: { email } });
+			// eslint-disable-next-line prefer-promise-reject-errors
+			if (user) return Promise.reject('user_conflict');
+		}),
+	body('password', 'A strong password required')
+		.isStrongPassword()
+		.bail()
+		.customSanitizer((value) => {
+			const hash = bcrypt.hash(value, 10);
+			return hash;
+		}),
+	body('firstName', 'This too is required').notEmpty(),
+	body('lastName', 'This too is required').notEmpty(),
+	body('role', 'This too is required').notEmpty(),
+];
+
+export const validate = (req, res, next) => {
+	const errors = validationResult(req);
+	if (errors.isEmpty()) return next();
+	const extractedErrors = {};
+	errors.array().forEach((err) => {
+		extractedErrors[err.param] = err.msg;
+	});
+	return res.status(400).json({ extractedErrors });
+};

--- a/src/routes/apiRouter.js
+++ b/src/routes/apiRouter.js
@@ -1,12 +1,19 @@
 import { Router } from 'express';
 import handleResponse from '../controllers/handleResponse.js';
-import userRouter from './userRouter.js';
 import accountsRouter from './accountsRouter.js';
+import companyRouter from './companiesRouter.js';
+import driverRouter from './driverRouter.js';
+import operatorRouter from './operatorRoutes.js';
+import userRouter from './userRouter.js';
 
 const apiRouter = Router();
 
 apiRouter.use('/users', userRouter);
 apiRouter.use('/accounts', accountsRouter);
+apiRouter.use('/operators', operatorRouter);
+apiRouter.use('/companies', companyRouter);
+apiRouter.use('/drivers', driverRouter);
+
 apiRouter.all('*', (req, res) =>
 	handleResponse(res, 200, { message: res.__('welcomeAPI') })
 );

--- a/src/routes/companiesRouter.js
+++ b/src/routes/companiesRouter.js
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import handleResponse from '../controllers/handleResponse.js';
+import verifyToken from '../middlewares/authJwt.js';
+import CheckPermissionAny, {
+	CheckPermissionOwn,
+} from '../middlewares/CheckPermission.js';
+
+const genericViewFun = (req, res) =>
+	handleResponse(res, 200, { message: 'You are authorized.' });
+const resource = 'companies';
+const companyRouter = Router();
+
+companyRouter.get(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+companyRouter.post(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+companyRouter.put(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+companyRouter.delete(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+companyRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+companyRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+companyRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+companyRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+
+export default companyRouter;

--- a/src/routes/driverRouter.js
+++ b/src/routes/driverRouter.js
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import handleResponse from '../controllers/handleResponse.js';
+import verifyToken from '../middlewares/authJwt.js';
+import CheckPermissionAny, {
+	CheckPermissionOwn,
+} from '../middlewares/CheckPermission.js';
+
+const genericViewFun = (req, res) =>
+	handleResponse(res, 200, { message: 'You are authorized.' });
+const resource = 'drivers';
+const driverRouter = Router();
+
+driverRouter.get(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+driverRouter.post(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+driverRouter.put(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+driverRouter.delete(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+driverRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+driverRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+driverRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+driverRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+
+export default driverRouter;

--- a/src/routes/operatorRoutes.js
+++ b/src/routes/operatorRoutes.js
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import handleResponse from '../controllers/handleResponse.js';
+import verifyToken from '../middlewares/authJwt.js';
+import CheckPermissionAny, {
+	CheckPermissionOwn,
+} from '../middlewares/CheckPermission.js';
+
+const genericViewFun = (req, res) =>
+	handleResponse(res, 200, { message: 'You are authorized.' });
+const resource = 'operators';
+const operatorRouter = Router();
+
+operatorRouter.get(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+operatorRouter.post(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+operatorRouter.put(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+operatorRouter.delete(
+	'/',
+	verifyToken,
+	CheckPermissionAny(resource),
+	genericViewFun
+);
+operatorRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+operatorRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+operatorRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+operatorRouter.get(
+	'/:id',
+	verifyToken,
+	CheckPermissionOwn(resource),
+	genericViewFun
+);
+
+export default operatorRouter;

--- a/src/routes/tests/rolesTest.test.js
+++ b/src/routes/tests/rolesTest.test.js
@@ -1,0 +1,157 @@
+import bcrypt from 'bcrypt';
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../app.js';
+import logger from '../../configs/winston.js';
+import AppDataSource from '../../data-source.js';
+import User from '../../models/user.js';
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('ROLES AND PERMISSIONS', async () => {
+	before(async () => {
+		try {
+			await AppDataSource.query('TRUNCATE "User" CASCADE');
+		} catch (error) {
+			logger.error(error.message);
+		}
+	});
+	let token;
+	describe('Driver accessing routes', async () => {
+		before(async () => {
+			const password = await bcrypt.hash('Andela@1234', 5);
+			const user = {
+				email: 'driver@gmail.com',
+				password,
+				firstName: 'Test',
+				lastName: 'Last',
+				role: 'driver',
+			};
+			const saveUser = User.create(user);
+			await saveUser.save();
+			const res = await chai.request(app).post('/api/v1/accounts/login').send({
+				email: 'driver@gmail.com',
+				password: 'Andela@1234',
+			});
+			token = res.body.data.access_token;
+		});
+		it('Should return a list of users', async () => {
+			const res = await chai
+				.request(app)
+				.get('/api/v1/users')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Should allow edit of own profile', async () => {
+			const res = await chai
+				.request(app)
+				.put('/api/v1/drivers/123')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Return error for updating drivers', async () => {
+			const res = await chai
+				.request(app)
+				.put('/api/v1/drivers')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(401);
+		});
+		it('Return unauthorized for creating driver', async () => {
+			const res = await chai
+				.request(app)
+				.post('/api/v1/drivers')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(401);
+		});
+		it('Return unauthorized for deleting driver', async () => {
+			const res = await chai
+				.request(app)
+				.delete('/api/v1/drivers')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(401);
+		});
+		it('Return unauthorized for getting operators', async () => {
+			const res = await chai
+				.request(app)
+				.post('/api/v1/operators')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(401);
+		});
+		it('Return unauthorized for invalid token', async () => {
+			const res = await chai
+				.request(app)
+				.post('/api/v1/operators')
+				.set('Authorization', `Bearer 123hdgdhdjjdhf`);
+			expect(res).to.have.status(401);
+		});
+	});
+	describe('Operator accessing routes', async () => {
+		before(async () => {
+			const password = await bcrypt.hash('Andela@1234', 5);
+			const user = {
+				email: 'operator@gmail.com',
+				password,
+				firstName: 'Test',
+				lastName: 'Last',
+				role: 'operator',
+			};
+			const saveUser = User.create(user);
+			await saveUser.save();
+			const res = await chai.request(app).post('/api/v1/accounts/login').send({
+				email: 'operator@gmail.com',
+				password: 'Andela@1234',
+			});
+			token = res.body.data.access_token;
+		});
+		it('Should return a list of users', async () => {
+			const res = await chai
+				.request(app)
+				.get('/api/v1/users')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Should allow edit of own profile', async () => {
+			const res = await chai
+				.request(app)
+				.put('/api/v1/drivers/123')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Return error for updating drivers', async () => {
+			const res = await chai
+				.request(app)
+				.put('/api/v1/drivers')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Return unauthorized for creating driver', async () => {
+			const res = await chai
+				.request(app)
+				.post('/api/v1/drivers')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Return unauthorized for deleting driver', async () => {
+			const res = await chai
+				.request(app)
+				.delete('/api/v1/drivers')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(200);
+		});
+		it('Return unauthorized for getting operators', async () => {
+			const res = await chai
+				.request(app)
+				.post('/api/v1/operators')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(401);
+		});
+		it('Return a raised an error', async () => {
+			const res = await chai
+				.request(app)
+				.delete('/api/v1/users')
+				.set('Authorization', `Bearer ${token}`);
+			expect(res).to.have.status(500);
+		});
+	});
+});

--- a/src/routes/tests/userRouter.test.js
+++ b/src/routes/tests/userRouter.test.js
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
-import server from '../../app.js';
+import app from '../../app.js';
 import logger from '../../configs/winston.js';
 import DataSource from '../../data-source.js';
 
@@ -16,34 +16,37 @@ describe('userRouter', () => {
 			logger.error(error.message);
 		}
 	});
-	it('it should get all users', async () => {
-		const response = await chai.request(server).get('/api/v1/users');
-		expect(response).to.have.status(200);
-		expect(response.body.data).to.have.length(0);
+
+	it('it should raise an authorization error', async () => {
+		const response = await chai.request(app).get('/api/v1/users');
+		expect(response).to.have.status(401);
 	});
 	it('it should create a new user', async () => {
-		const response = await chai.request(server).post('/api/v1/users').send({
+		const response = await chai.request(app).post('/api/v1/users').send({
 			firstName: 'Fabrice',
 			lastName: 'Ivad',
 			email: 'test@mail.com',
-			password: '1234',
+			password: 'Andela@1234',
+			role: 'operator',
 		});
 		expect(response).to.have.status(201);
 		expect(response.body.data)
 			.to.have.property('email')
 			.to.equal('test@mail.com');
+		expect(response.body.data).not.have.property('password');
 	});
 	it('it should return a conflict error', async () => {
-		const response = await chai.request(server).post('/api/v1/users').send({
+		const response = await chai.request(app).post('/api/v1/users').send({
 			firstName: 'Fabrice',
 			lastName: 'Ivad',
 			email: 'test@mail.com',
-			password: '1234',
+			password: 'Andela@123',
+			role: 'admin',
 		});
-		expect(response).to.have.status(409);
+		expect(response).to.have.status(400);
 	});
 	it('it should return raise a validation error', async () => {
-		const response = await chai.request(server).post('/api/v1/users').send({
+		const response = await chai.request(app).post('/api/v1/users').send({
 			email: 'test1@mail.com',
 			password: '1234',
 		});

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -1,9 +1,20 @@
 import { Router } from 'express';
 import { CreateUser, GetUsers } from '../controllers/user.js';
+import verifyToken from '../middlewares/authJwt.js';
+import CheckPermission from '../middlewares/CheckPermission.js';
+import raiseError from '../rolesApp/controller.js';
+import { createUserValidation, validate } from '../rolesApp/validation.js';
+import asyncHandler from '../utils/asyncHandler.js';
 
 const router = Router();
 
-router.get('/', GetUsers);
-router.post('/', CreateUser);
+router.get('/', verifyToken, CheckPermission('drivers'), GetUsers);
+router.post('/', createUserValidation(), validate, CreateUser);
+router.delete(
+	'/',
+	verifyToken,
+	CheckPermission('drivers'),
+	asyncHandler(raiseError)
+);
 
 export default router;

--- a/src/utils/errorLogger.js
+++ b/src/utils/errorLogger.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+
+const errorMessage = [
+	'Something happened on our end. We have been notified',
+	'These things happen sometimes. Try again after after some time.',
+	'Ooops! Our problem. We are looking into this one',
+];
+
+const errLogger = (error, req, res, next) => {
+	let at = error.stack.split(/\r\n|\r|\n/)[1];
+	console.error(`${error.message}- happended at \n ${at}`);
+
+	if (error instanceof SyntaxError && error.status === 400 && 'body' in error) {
+		return res
+			.status(406)
+			.send({ code: 406, status: 'fail', message: error.message }); // Bad request
+	} else {
+		return handleResponse(
+			res,
+
+			500,
+			errorMessage[Math.floor(Math.random() * errorMessage.length)]
+		);
+	}
+};
+
+export default errLogger;


### PR DESCRIPTION
:arrow_right: :arrow_right: The permissions and roles are strict for :thumbsdown: **`[C|R|U|D]`** which means allowed requests are 
```js
CREATE | POST
READ | GET
UPDATE| PUT
DELETE | DELETE
```
Avoid using other types such as :thumbsdown: **PATCH** when using the permission check.

### What does this PR do?

- [x] Administrator should be able to **[C|R|U|D]** roles
- [x] The administrator should be able to set and update role's permissions
- [x] Access control has been implemented and put in place
- [x] Appropriate error message are displayed on unsuccessful attempts.

### Description of Task to be completed
As **an administrator**, I want to be able to create the role and set its permissions, so that different users can only access & perform data/operations to which they are authorized.

**Roles**

- Driver
- Operator
- Administrator
> Refer to this [Trello Card](https://trello.com/c/cfsTKeAY) for extended overview of the background
### How should this be manually tested?
Since roles are granted and checked on user basis.
> There are no required additional environment configuration to test these roles just remember to `npm install` when you get to it. 

### Postman
To navigate the tests, create the users with different roles (**Note that this feature will be removed in the future**). **[admin, driver, operator]. And with the information from the above mentioned roles and their permissions can be found in the linked **Trello card**. Use the listed routes bellow in postman to tests how protection work.
> **Special attention**: To check for attribute based roles and permissions. Pay more attention on the attributes of the data that you will get back. Since this matters a lot.
> Protected resources are: **[`drivers, operators, routes, companies`]** users are used for testing purpose only in this PR.

#### Testing routes:
```js
// remember to add your host like <http://localhost:<PORT>>
//create an account with role property among [admin, driver, operator] if no role passed, it default to user
POST: /api/v1/users   =>{...info, role:(admin|driver|operator)

// Drivers
(C|R|U|D): /api/v1/drivers
(C|R|U|D): /api/v1/drivers/1234

// operators **Operator|Admin**
(C|R|U|D): /api/v1/operators
(C|R|U|D): /api/v1/operatots/1234

// companies **Admin only**
(C|R|U|D): /api/v1/companies
(C|R|U|D): /api/v1/companies/1234

```
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/19126547-9b063390-df96-4fff-ba14-af8649100478?action=collection%2Ffork&collection-url=entityId%3D19126547-9b063390-df96-4fff-ba14-af8649100478%26entityType%3Dcollection%26workspaceId%3D252017b1-dc09-4cf8-ad20-ea23c74ad4d7)
### Any background context you want to provide?
Access control is being handled by a really great package that you can access here:
> [AccessControlPackage](https://github.com/onury/accesscontrol#guide)
### What are the relevant pivotal tracker stories?
- [#CP-9](https://trello.com/c/cfsTKeAY)
### Screenshots (if appropriate)