### PR TITLE
#CP-21 feat:  Logout from account

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -15,7 +15,7 @@
 	"user does not exist": "user does not exist",
 	"wrong email or password": "wrong email or password",
 	"you need to login first": "you need to login first",
-	"Server error": "Server error",
 	"Unauthorized": "Unauthorized access",
-	"Password or email is invalid": "Password or email is invalid"
+	"Password or email is invalid": "Password or email is invalid",
+	"logout successful": "Successfully logged out"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -13,8 +13,9 @@
 	"password_required": "Mot de passe is requis",
 	"user_conflict": "L'utilisateur avec cet email existe",
 	"user does not exist": "l'utilisateur n'existe pas",
-	"wrong email or password": "mauvais email ou password",
-	"you need to login first": "tu dois d'abord te connecter",
 	"Unauthorized": "L'accès non autorisé",
-	"Password or email is invalid": "Le mot de passe ou l'e-mail est invalide"
+	"Password or email is invalid": "Le mot de passe ou l'e-mail est invalide",
+	"wrong email or password": "Mauvais email ou mot de passe",
+	"you need to login first": "Tu dois d'abord te connecter",
+	"logout successful": "Déconnecté avec succès"
 }

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -15,7 +15,7 @@
 	"user does not exist": "iyi konti ntayihari",
 	"wrong email or password": "mwibeshye imeri cyangwa umubare w'ibanga",
 	"you need to login first": "ugomba kubanza kwinjira",
-	"Server error": "Server error",
 	"Unauthorized": "Nta burenganzira ubifitiye",
-	"Password or email is invalid": "Ijambo banga cyangwa imeri ntabwo byemewe"
+	"Password or email is invalid": "Ijambo banga cyangwa imeri ntabwo byemewe",
+	"logout successful": "Gusohoka byagenze neza"
 }

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -9,7 +9,7 @@ const AuthHandler = async (req, res) => {
 	const user = await User.findOneBy({ email: req.body.email });
 	if (!user) {
 		return handleResponse(res, 400, {
-			message: res.__('Password or email is invalid'),
+			message: res.__('wrong email or password'),
 		});
 	}
 	try {

--- a/src/controllers/logout.controller.js
+++ b/src/controllers/logout.controller.js
@@ -1,0 +1,22 @@
+import 'dotenv/config';
+import RefreshToken from '../models/refreshToken.js';
+import handleResponse from './handleResponse.js';
+
+const logout = async (req, res) => {
+	const { cookies } = req;
+	const accessToken = req.headers.authorization;
+	if (!cookies.jwt && !accessToken) {
+		return handleResponse(res, 200, { message: res.__('logout successful') });
+	}
+	/* c8 ignore next 8 */
+	if (cookies.jwt) {
+		const token = await RefreshToken.findOneBy({ token: cookies.jwt });
+		await token.remove();
+		if (!accessToken) {
+			res.cookie('jwt', '', { httpOnly: true, maxAge: 1 });
+			return handleResponse(res, 200, { message: res.__('logout successful') });
+		}
+	}
+};
+
+export { logout };

--- a/src/controllers/refreshToken.controller.js
+++ b/src/controllers/refreshToken.controller.js
@@ -34,7 +34,7 @@ const refresh = async (req, res) => {
 		return handleResponse(res, 200, { token: accessToken });
 		/* c8 ignore next 3 */
 	} catch (err) {
-		handleResponse(res, 500, { message: res.__('Server error') });
+		handleResponse(res, 500, { message: res.__('serverError') });
 	}
 };
 

--- a/src/controllers/tests/auth.test.js
+++ b/src/controllers/tests/auth.test.js
@@ -14,7 +14,7 @@ describe('LOGIN', () => {
 	before((done) => {
 		server.on('started', async () => {
 			try {
-				await DataSource.synchronize();
+				await DataSource.query('TRUNCATE "User" CASCADE');
 			} catch (error) {
 				logger.error(error.message);
 			} finally {

--- a/src/controllers/tests/logout.test.js
+++ b/src/controllers/tests/logout.test.js
@@ -1,0 +1,60 @@
+import dotenv from 'dotenv';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import DataSource from '../../data-source.js';
+import logger from '../../configs/winston.js';
+import server from '../../app.js';
+
+dotenv.config();
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('LOGOUT', () => {
+	before(async () => {
+		try {
+			await DataSource.query('TRUNCATE "RefreshToken" CASCADE');
+			await DataSource.query('TRUNCATE "User" CASCADE');
+		} catch (error) {
+			logger.error(error.message);
+		}
+	});
+
+	describe('LOGOUT from the account', () => {
+		it('it should logout a user from the account ', (done) => {
+			chai
+				.request(server)
+				.post('/api/v1/users')
+				.send({
+					firstName: 'Patrick',
+					lastName: 'Shema',
+					email: 'patrickshema@gmail.com',
+					password: 'Andela@123',
+					role: 'admin',
+				})
+				.end((err, res) => {
+					res.should.have.status(201);
+					chai
+						.request(server)
+						.post('/api/v1/accounts/login')
+						.send({
+							email: 'patrickshema@gmail.com',
+							password: 'Andela@123',
+						})
+						.end((err, res) => {
+							res.should.have.status(200);
+							chai
+								.request(server)
+								.get('/api/v1/accounts/logout')
+								.end((err, res) => {
+									res.should.have.status(200);
+									res.body.should.be.a('object');
+									res.body.should.have.property('data');
+									res.body.data.should.have.property('message');
+									done();
+								});
+						});
+				});
+		});
+	});
+});

--- a/src/docs/loginRouter.docs.js
+++ b/src/docs/loginRouter.docs.js
@@ -7,20 +7,7 @@
 
 /**
  * @swagger
- * /api/v1/logout:
- *  get:
- *      summary: Logout from phantom
- *      description: The
- *      tags:
- *          - Logout
- *      responses:
- *          200:
- *              description: successfully logged out
- */
-
-/**
- * @swagger
- * /api/v1/login:
+ * /api/v1/accounts/login:
  *  post:
  *      summary: Login into phantom
  *      description: The user is able to login into phantom

--- a/src/docs/logoutRouter.docs.js
+++ b/src/docs/logoutRouter.docs.js
@@ -1,0 +1,19 @@
+/**
+ * @openapi
+ * tags:
+ *  name: Authentication
+ *  description: Routes for authentication
+ */
+
+/**
+ * @swagger
+ * /api/v1/accounts/logout:
+ *  get:
+ *      summary: Logout from phantom
+ *      description: The user is able to logout from the account
+ *      tags:
+ *          - Logout
+ *      responses:
+ *          200:
+ *              description: successfully logged out
+ */

--- a/src/docs/refreshRouter.docs.js
+++ b/src/docs/refreshRouter.docs.js
@@ -1,0 +1,19 @@
+/**
+ * @openapi
+ * tags:
+ *  name: Authentication
+ *  description: Routes for authentication
+ */
+
+/**
+ * @swagger
+ * /api/v1/accounts/refresh:
+ *  get:
+ *      summary: Get a new token
+ *      description: The user can get a new token when the first one expires
+ *      tags:
+ *          - Refresh
+ *      responses:
+ *          200:
+ *              description: successfully logged out
+ */

--- a/src/routes/accountsRouter.js
+++ b/src/routes/accountsRouter.js
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import loginRouter from './loginRouter.js';
+import logoutRouter from './logoutRouter.js';
 import { refresh } from '../controllers/refreshToken.controller.js';
 
 const apiRouter = Router();
 
 apiRouter.use('/login', loginRouter);
 apiRouter.get('/refresh', refresh);
+apiRouter.use('/logout', logoutRouter);
 
 export default apiRouter;

--- a/src/routes/logoutRouter.js
+++ b/src/routes/logoutRouter.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { logout } from '../controllers/logout.controller.js';
+
+const router = express.Router();
+
+router.get('/', logout);
+
+export default router;

--- a/src/utils/clearCookie.js
+++ b/src/utils/clearCookie.js
@@ -1,0 +1,6 @@
+export const clearCookie = (res) =>
+	res.cookie('jwt', '', { httpOnly: true, maxAge: 1 }).status(200).json({
+		status: 'success',
+		code: 200,
+		data: {},
+	});


### PR DESCRIPTION
#### What does this PR do?
Gives an authenticated user the ability to logout, so that none else can access their account as well.

#### Description of the tasks to be completed
- [x] Authenticated user should be able to logout.
- [x] Authenticated user should be able to access protected resourses/URLs.
- [x] Appropriate error messages are displayed on unsuccessful attempts.

#### How should this be manually tested?
**Configure your environment based on the `.env.sample.md` then follow the following:**
```js
git checkout ft-logout-cp-21
git fetch
npm install
// if you don't have postgres installed, refer to the README for instructions
npm start
```
> **Testing the login route**
Use the below endpoints
```
POST   /api/v1/users    //Creating a user with {firstName, lastName, email & password}
POST   /api/v1/login    //Sign in with {email & password}
GET   /api/v1/logout    //Logout
```
#### Pre-requisites:

- Clone the project
- Make sure that Postgres is up and running

#### What are the relevant trello stories?
[#CP-21](https://trello.com/c/bhS4kERe/21-logout-from-account)