### PR TITLE
#CP-22 bug: Fix status code for request forbidden

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+{::comment} # _Title_: #162836478 Create the signup feature {:/comment}
+{::comment} _description_{:/comment}
+
+### What does this PR do?
+
+{::comment} Explain the why/what not the how {:/comment}
+
+{::comment} [what the PR does] {:/comment}
+
+### Description of Task to be completed
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+### How should this be manually tested?
+
+{::comment} Remember to add the code block {:/comment}
+
+```
+git clone https://github.com/atlp-rwanda/phantom-be-codebandits
+cd phantom-be-codebandits
+git fetch origin
+git checkout <your branch>
+npm install
+//configure the .env according to the .env.sample file
+// start the database
+npm run dev
+// open browser or postman (Check linked public workplace for testing)
+```
+
+### Any background context you want to provide?
+
+{::comment} Explain the packages you may have used, some unusual coding patterns you have added and so on {:/comment}
+
+### What are the relevant pivotal tracker stories?
+
+{::comment} ["<Trello card id>"](<"Trello card url">) {:/comment}
+
+### Screenshots (if appropriate)

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,43 @@
+# Start writting at line 16
+# ----------------------------------------------------------
+# Header - type(scope): Brief description (try to keep under 50 characters)
+# ----------------------------------------------------------
+#    * feat             A new feature - PATCH
+#    * fix              A bug fix - MINOR
+#    * docs             Change to documentation only
+#    * style            Change to style (whitespace, etc.)
+#    * refactor         Change not related to a bug or feat
+#    * perf             Change that affects performance
+#    * test             Change that adds/modifies tests
+#    * build            Change to build system
+#    * ci               Change to CI pipeline/workflow
+#    * chore            General tooling/config/min refactor
+# ----------------------------------------------------------
+# feat(auth): create sign up page
+
+# ----------------------------------------------------------
+# Body - More description, if necessary
+# ----------------------------------------------------------
+#    * Motivation behind changes, more detail into how
+#      *functionality might be affected, etc.
+#   - create the ui for the feature
+#   - modify some components
+# ----------------------------------------------------------
+
+
+# ----------------------------------------------------------
+# Footer - Associated issues, PRs, Trello card .
+# ----------------------------------------------------------
+#    * Ex: Finishes [#CP-45]
+# ----------------------------------------------------------
+
+
+# ----------------------------------------------------------
+# Co-authors - Give credit, where credit is due. 
+# Use the format and ensure to use private email
+# ----------------------------------------------------------
+#    * Ex: Co-authored-by: name <28519395+feyton@users.noreply.github.com>
+# ----------------------------------------------------------
+
+
+# Start below this line for co-authors

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 This is a the backend repository for Phantom project which is an application that aims at addressing a problem of commuters in Kigali who spend a long time at the bus stations or in queues waiting for buses to come. it will allow simulating bus movements and enabling passengers to track their locations & movements.
 
-- [] Check out Phantom frontend repository [linked here](https://github.com/atlp-rwanda/phantom-fe-codebandits)
-- [] Check the hosted Frontend application [linked here](https://phantom-codebantis.herokuapp.com)
+- [ ] Check out Phantom frontend repository [linked here](https://github.com/atlp-rwanda/phantom-fe-codebandits)
+- [ ] Check the hosted Frontend application [linked here](https://phantom-codebantis.herokuapp.com)
 
 ## Getting Started
 
@@ -51,7 +51,7 @@ npm run start // to start in watch mode use <npm run dev>
 
 You can configure the application with the following [environment variables]:
 
-> Refer to the `.env.sample.md` file for the configuration required
+> Refer to the `.env.sample` file for the configuration required
 
 #### Docker container for testing
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -47,5 +47,6 @@
 	"license_ID_exist": "User with provided license exists",
 	"A strong password required": "A strong password required",
 	"This too is required": "This too is required",
-	"operator_updated": "Operator updated successfully"
+	"operator_updated": "Operator updated successfully",
+	"Permission denied": "Permission denied"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -39,5 +39,6 @@
 	"driver_updated": "Le pilote a été mis à jour avec succès",
 	"national_ID_exist": "L'utilisateur avec l'ID national fourni existe",
 	"license_ID_exist": "L'utilisateur avec la licence fournie existe",
-	"operator_updated": "Opérateur mis à jour avec succès"
+	"operator_updated": "Opérateur mis à jour avec succès",
+	"Permission denied": "Permission refusée"
 }

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -41,5 +41,6 @@
 	"driver_updated": "Umushoferi yahinduwe neza",
 	"national_ID_exist": "indangamuntu yatanzwe isanzwe iri muri sisitemu",
 	"license_ID_exist": "uruhushya rwatanzwe rusanzwe muri sisitemu",
-	"operator_updated": "Umukoresha yahinduwe neza"
+	"operator_updated": "Umukoresha yahinduwe neza",
+	"Permission denied": "Uruhushya rwanze"
 }

--- a/src/configs/tests/dummyData.js
+++ b/src/configs/tests/dummyData.js
@@ -1,0 +1,103 @@
+import bcrypt from 'bcrypt';
+
+const dataFn = async () => {
+	const password = await bcrypt.hash('Andela@1234', 5);
+	const data = {
+		users: {
+			admin: {
+				email: 'admin@gmail.com',
+				password,
+				firstName: 'test',
+				lastName: 'Andela',
+				role: 'admin',
+			},
+			operator: {
+				email: 'operator@gmail.com',
+				password,
+				firstName: 'test',
+				lastName: 'Andela',
+				role: 'operator',
+			},
+			driver: {
+				email: 'driver@gmail.com',
+				password,
+				firstName: 'test',
+				lastName: 'Andela',
+				role: 'driver',
+			},
+			user: {
+				email: 'user@gmail.com',
+				password,
+				firstName: 'test',
+				lastName: 'Andela',
+				role: 'user',
+			},
+			reset: {
+				email: 'testreset@gmail.com',
+				password,
+				firstName: 'test',
+				lastName: 'Andela',
+				role: 'admin',
+			},
+			resetToken: {
+				email: 'testtoken@gmail.com',
+				password,
+				firstName: 'test',
+				lastName: 'Andela',
+				role: 'admin',
+			},
+		},
+		operators: {
+			valid: {
+				firstName: 'testName',
+				lastName: 'testname2',
+				email: 'tiktok@me.com',
+				mobileNumber: '0788352746',
+				company: 'Virunga express',
+				address: 'Kabuga, Kigali',
+				nationalID: '1199880081691164',
+			},
+			edit: {
+				lastName: 'Samuel',
+				firstName: 'Shyaka',
+				wrongKey: 'nananana',
+				email: 'yvesivad@gmail.com',
+				role: 'admin',
+				mobileNumber: '0788231378',
+			},
+			invalid: {
+				firstName: 'testName',
+				lastName: 'testname2',
+				password: 'Password@123',
+				mobileNumber: '0788352746',
+				company: 'Virunga express',
+				address: 'Kabuga, Kigali',
+				nationalID: '1199880081691164',
+			},
+		},
+		drivers: {
+			valid: {
+				firstName: 'testName',
+				lastName: 'testname2',
+				email: 'tiktok@me.com',
+				mobileNumber: '0788352746',
+				company: 'Kigali Bus Services',
+				address: 'Kabuga, Kigali',
+				nationalID: '1200080081691164',
+				license: '1200080081691164',
+			},
+			edit: {
+				lastName: 'Samuel',
+				firstName: 'Shyaka',
+				wrongKey: 'nananana',
+				email: 'yvesivad@gmail.com',
+				role: 'admin',
+				mobileNumber: '0788231378',
+			},
+		},
+	};
+
+	return data;
+};
+
+export default dataFn;

--- a/src/driverApp/tests/driver.test.js
+++ b/src/driverApp/tests/driver.test.js
@@ -1,7 +1,7 @@
-import bcrypt from 'bcrypt';
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../../app.js';
+import dataFn from '../../configs/tests/dummyData.js';
 import logger from '../../configs/winston.js';
 import DataSource from '../../data-source.js';
 import User from '../../models/user.js';
@@ -21,16 +21,11 @@ describe('driver router tests', () => {
 	let token;
 	let createdDriverId;
 	let driverInfo;
-	it('should login an admin user', async () => {
-		const password = await bcrypt.hash('Andela@1234', 5);
-		const newUser = User.create({
-			email: 'test123@gmail.com',
-			password,
-			firstName: 'test',
-			lastName: 'Andela',
-			role: 'admin',
-		});
-		const user = await newUser.save();
+	let data;
+	it('should login an operator user', async () => {
+		data = await dataFn();
+		driverInfo = data.drivers.valid;
+		const user = await User.createAndSave(data.users.operator);
 		const info = { email: user.email, password: 'Andela@1234' };
 		const response = await chai
 			.request(app)
@@ -48,16 +43,6 @@ describe('driver router tests', () => {
 		expect(response.body.data).to.have.length(0);
 	});
 	it('should create a new driver', async () => {
-		driverInfo = {
-			firstName: 'testName',
-			lastName: 'testname2',
-			email: 'tiktok@me.com',
-			mobileNumber: '0788352746',
-			company: 'Kigali Bus Services',
-			address: 'Kabuga, Kigali',
-			nationalID: '1200080081691164',
-			license: '1200080081691164',
-		};
 		const response = await chai
 			.request(app)
 			.post('/api/v1/drivers')
@@ -82,18 +67,10 @@ describe('driver router tests', () => {
 		expect(response).to.have.status(200);
 	});
 	it('should edit a driver', async () => {
-		const editInfo = {
-			lastName: 'Samuel',
-			firstName: 'Shyaka',
-			wrongKey: 'nananana',
-			email: 'yvesivad@gmail.com',
-			role: 'admin',
-			mobileNumber: '0788231378',
-		};
 		const response = await chai
 			.request(app)
 			.put(`/api/v1/drivers/${createdDriverId}`)
-			.send(editInfo)
+			.send(data.drivers.edit)
 			.set('Authorization', `Bearer ${token}`);
 		expect(response).to.have.status(200);
 		expect(response.body.data).to.contain('Driver updated successfully');

--- a/src/middlewares/CheckPermission.js
+++ b/src/middlewares/CheckPermission.js
@@ -11,31 +11,32 @@ const CheckPermissionAny = (resource) => async (req, res, next) => {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
+			return handleResponse(res, 403, res.__('Permission denied'));
 		case 'POST':
 			permission = ac.can(req.user.role).createAny(resource);
 			if (permission.granted) {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
+			return handleResponse(res, 403, res.__('Permission denied'));
 		case 'PUT':
 			permission = ac.can(req.user.role).updateAny(resource);
 			if (permission.granted) {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
+			return handleResponse(res, 403, res.__('Permission denied'));
+
 		case 'DELETE':
 			permission = ac.can(req.user.role).deleteAny(resource);
 			if (permission.granted) {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
-
+			return handleResponse(res, 403, res.__('Permission denied'));
+		/* c8 ignore next 3 */
 		default:
-			return handleResponse(res, 403, 'Permission denied');
+			return handleResponse(res, 403, res.__('Permission denied'));
 	}
 };
 export default CheckPermissionAny;
@@ -50,29 +51,29 @@ export const CheckPermissionOwn = (resource) => async (req, res, next) => {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
+			return handleResponse(res, 403, res.__('Permission denied'));
 		case 'POST':
 			permission = ac.can(req.user.role).createOwn(resource);
 			if (permission.granted) {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
+			return handleResponse(res, 403, res.__('Permission denied'));
 		case 'PUT':
 			permission = ac.can(req.user.role).updateOwn(resource);
 			if (permission.granted) {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
+			return handleResponse(res, 403, res.__('Permission denied'));
 		case 'DELETE':
 			permission = ac.can(req.user.role).deleteOwn(resource);
 			if (permission.granted) {
 				req.attributes = permission.attributes;
 				return next();
 			}
-			return handleResponse(res, 401, res.__('Unauthorized'));
-
+			return handleResponse(res, 403, res.__('Permission denied'));
+		/* c8 ignore next 3 */
 		default:
 			return handleResponse(res, 403, 'Permission denied');
 	}

--- a/src/middlewares/authJwt.js
+++ b/src/middlewares/authJwt.js
@@ -7,7 +7,7 @@ const verifyToken = (req, res, next) => {
 	const authHeader = req.headers.authorization;
 	const token = authHeader && authHeader.split(' ')[1];
 	if (token == null)
-		return res.status(401).send({
+		return res.status(401).json({
 			status: 'fail',
 			code: 401,
 			message: 'Unauthorized with token',
@@ -15,7 +15,7 @@ const verifyToken = (req, res, next) => {
 
 	jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, (err, user) => {
 		if (err)
-			return res.status(401).send({
+			return res.status(401).json({
 				status: 'error',
 				code: 401,
 				message: err,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -12,6 +12,12 @@ export class User extends BaseEntity {
 	lastName;
 
 	role;
+
+	static async createAndSave(data) {
+		const user = this.create(data);
+		const saveUser = await user.save();
+		return saveUser;
+	}
 }
 
 export const UserSchema = new EntitySchema({

--- a/src/operatorApp/tests/operator.test.js
+++ b/src/operatorApp/tests/operator.test.js
@@ -1,7 +1,7 @@
-import bcrypt from 'bcrypt';
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../../app.js';
+import dataFn from '../../configs/tests/dummyData.js';
 import logger from '../../configs/winston.js';
 import DataSource from '../../data-source.js';
 import User from '../../models/user.js';
@@ -10,6 +10,8 @@ chai.use(chaiHttp);
 chai.should();
 
 describe('Operator router tests', () => {
+	let data;
+	let operatorInfo;
 	before(async () => {
 		try {
 			await DataSource.query('TRUNCATE "Operator" CASCADE');
@@ -18,19 +20,19 @@ describe('Operator router tests', () => {
 			logger.error(error.message);
 		}
 	});
-	let operatorInfo;
+	it('Should setup tests', async () => {
+		data = await dataFn();
+		expect(data.users.admin)
+			.to.have.property('email')
+			.to.equal('admin@gmail.com');
+		operatorInfo = data.operators.valid;
+	});
+
 	let createdOperatorID;
 	let token;
 	it('should login an admin user', async () => {
-		const password = await bcrypt.hash('Andela@1234', 5);
-		const newUser = User.create({
-			email: 'test123@gmail.com',
-			password,
-			firstName: 'test',
-			lastName: 'Andela',
-			role: 'admin',
-		});
-		const user = await newUser.save();
+		const user = data.users.admin;
+		await User.createAndSave(user);
 		const info = { email: user.email, password: 'Andela@1234' };
 		const response = await chai
 			.request(app)
@@ -48,15 +50,6 @@ describe('Operator router tests', () => {
 		expect(response.body.data).to.have.length(0);
 	});
 	it('should create a new operator', async () => {
-		operatorInfo = {
-			firstName: 'testName',
-			lastName: 'testname2',
-			email: 'tiktok@me.com',
-			mobileNumber: '0788352746',
-			company: 'Virunga express',
-			address: 'Kabuga, Kigali',
-			nationalID: '1199880081691164',
-		};
 		const response = await chai
 			.request(app)
 			.post('/api/v1/operators')
@@ -88,18 +81,10 @@ describe('Operator router tests', () => {
 		expect(response).to.have.status(200);
 	});
 	it('should edit an operator', async () => {
-		const editInfo = {
-			lastName: 'Samuel',
-			firstName: 'Shyaka',
-			wrongKey: 'nananana',
-			email: 'yvesivad@gmail.com',
-			role: 'admin',
-			mobileNumber: '0788231378',
-		};
 		const response = await chai
 			.request(app)
 			.put(`/api/v1/operators/${createdOperatorID}`)
-			.send(editInfo)
+			.send(data.operators.edit)
 			.set('Authorization', `Bearer ${token}`);
 		expect(response).to.have.status(200);
 		expect(response.body.data).to.contain('Operator updated successfully');
@@ -164,20 +149,87 @@ describe('Operator router tests', () => {
 		expect(response).to.have.status(404);
 	});
 	it('should raise validation error', async () => {
-		const operatorInfo = {
-			firstName: 'testName',
-			lastName: 'testname2',
-			password: 'Password@123',
-			mobileNumber: '0788352746',
-			company: 'Virunga express',
-			address: 'Kabuga, Kigali',
-			nationalID: '1199880081691164',
-		};
+		const response = await chai
+			.request(app)
+			.post('/api/v1/operators')
+			.send(data.operators.invalid)
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(400);
+	});
+	// Testing for logged in as an operator
+	it('should login an operator user', async () => {
+		const user = await User.createAndSave(data.users.operator);
+		const info = { email: user.email, password: 'Andela@1234' };
+		const response = await chai
+			.request(app)
+			.post('/api/v1/accounts/login')
+			.send(info);
+		expect(response).to.have.status(200);
+		token = response.body.data.access_token;
+	});
+	it('should not create an operator', async () => {
 		const response = await chai
 			.request(app)
 			.post('/api/v1/operators')
 			.send(operatorInfo)
 			.set('Authorization', `Bearer ${token}`);
-		expect(response).to.have.status(400);
+		expect(response).to.have.status(403);
+	});
+	it('should not delete an operator', async () => {
+		const response = await chai
+			.request(app)
+			.delete('/api/v1/operators/1234')
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(403);
+	});
+
+	// Logged as a driver
+
+	it('should login driver user', async () => {
+		const user = await User.createAndSave(data.users.driver);
+		const info = { email: user.email, password: 'Andela@1234' };
+		const response = await chai
+			.request(app)
+			.post('/api/v1/accounts/login')
+			.send(info);
+		expect(response).to.have.status(200);
+		token = response.body.data.access_token;
+	});
+	it('should not create an operator', async () => {
+		const response = await chai
+			.request(app)
+			.post('/api/v1/operators')
+			.send(operatorInfo)
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(403);
+	});
+	it('should not update an operator', async () => {
+		const response = await chai
+			.request(app)
+			.put('/api/v1/operators/1234')
+			.send(operatorInfo)
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(403);
+	});
+	it('should not delete an operator', async () => {
+		const response = await chai
+			.request(app)
+			.delete('/api/v1/operators/1234')
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(403);
+	});
+	it('should not get a list of operators', async () => {
+		const response = await chai
+			.request(app)
+			.get('/api/v1/operators')
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(403);
+	});
+	it('should not get operator profile', async () => {
+		const response = await chai
+			.request(app)
+			.get('/api/v1/operators/123')
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(403);
 	});
 });

--- a/src/routes/tests/rolesTest.test.js
+++ b/src/routes/tests/rolesTest.test.js
@@ -57,14 +57,14 @@ describe('ROLES AND PERMISSIONS', async () => {
 				.request(app)
 				.post('/api/v1/drivers')
 				.set('Authorization', `Bearer ${token}`);
-			expect(res).to.have.status(401);
+			expect(res).to.have.status(403);
 		});
 		it('Return unauthorized for getting operators', async () => {
 			const res = await chai
 				.request(app)
 				.post('/api/v1/operators')
 				.set('Authorization', `Bearer ${token}`);
-			expect(res).to.have.status(401);
+			expect(res).to.have.status(403);
 		});
 		it('Return unauthorized for invalid token', async () => {
 			const res = await chai
@@ -112,7 +112,7 @@ describe('ROLES AND PERMISSIONS', async () => {
 				.request(app)
 				.post('/api/v1/operators')
 				.set('Authorization', `Bearer ${token}`);
-			expect(res).to.have.status(401);
+			expect(res).to.have.status(403);
 		});
 		it('Return a raised an error', async () => {
 			const res = await chai


### PR DESCRIPTION
### What the PR does:
Ensure that all status code are matched with the standard status codes in regards to **Token verification** and **Access control**

### Background tasks to be completed

- [x] Fix the status code to match `403` for **Permission denied**
- [x] Fix the issue in `AuthVerify.js` that use `res.send` instead of `res.json`
### How should this be manually tested
Nothing changed in regards to environment setup if you have the project running.
Follow the specs for quick get started:
```js
git clone https://github.com/atlp-rwanda/phantom-be-codebandits
cd phantom-be-codebandits
touch .env // place the entries in .env.sample into this file
npm i
npm run dev
// remember to run your database
// Use POSTMAN or Swagger documentation by going to http://localhost:5000 <Replace "5000" with your "PORT">
```
### Background context
Prior to these changes we were using `401` status for both `Invalid token and missing permission` according to **[Mozilla Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses)** on `Status code`

> **401** code refer to missing token or invalid token. The server fail to identify the user.

> **403** code refer to missing required permissions. The server is able to identify the user, but the user misses the required permission. Which refers to the use of **Permission denied** status code in such instances

### Relevant Trello cards

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;pciaziF2&#x2F;22-status-code-in-response">Status code in response</a></blockquote>

<footer>

[Finishes #CP-22]