### PR TITLE
#CP-31 bug: backend quick fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10120,7 +10120,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"agent-base": {
 			"version": "6.0.2",
@@ -11618,7 +11619,8 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -14555,7 +14557,8 @@
 		"pg-pool": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
-			"integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ=="
+			"integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
+			"requires": {}
 		},
 		"pg-protocol": {
 			"version": "1.5.0",

--- a/src/busesApp/services.js
+++ b/src/busesApp/services.js
@@ -25,7 +25,7 @@ export const updateBus = async (Model, busId, editInfo) => {
 	const bus = await Model.findOneBy({ id: busId });
 	if (!bus) return false;
 
-	await Model.update(bus, editInfo);
+	await Model.updateById(bus.id, editInfo);
 	return true;
 };
 

--- a/src/busesApp/updateValidation.js
+++ b/src/busesApp/updateValidation.js
@@ -1,6 +1,14 @@
 import { body } from 'express-validator';
 
 const updateValidation = () => [
+	body('plateNumber')
+		.optional()
+		.toUpperCase()
+		.notEmpty()
+		.withMessage('plateNumber_required')
+		.bail()
+		.matches(/^R[A-Z]{1,4}[0-9]{1,4}[A-Z]{1}$/)
+		.withMessage('plateNumber_invalid'),
 	body('busType', 'busType_required')
 		.optional()
 		.notEmpty()
@@ -14,6 +22,7 @@ const updateValidation = () => [
 		.bail()
 		.isLength({ min: 2 })
 		.withMessage('min_2_char'),
+	body('company').optional(),
 ];
 
 export default updateValidation;

--- a/src/controllers/refreshToken.controller.js
+++ b/src/controllers/refreshToken.controller.js
@@ -7,14 +7,14 @@ const refresh = async (req, res) => {
 	try {
 		const { cookies } = req;
 		if (!cookies || !cookies.jwt) {
-			return handleResponse(res, 401, {
+			return handleResponse(res, 400, {
 				message: res.__('you need to login first'),
 			});
 		}
 		const refreshToken = cookies.jwt;
 		const userToken = await RefreshToken.findOneBy({ token: refreshToken });
 		if (!userToken) {
-			return handleResponse(res, 401, {
+			return handleResponse(res, 400, {
 				message: res.__('you need to login first'),
 			});
 		}
@@ -22,7 +22,7 @@ const refresh = async (req, res) => {
 		if (RefreshTokenSchema.verifyExpiration(userToken)) {
 			await userToken.remove();
 			res.clearCookie('jwt', { httpOnly: true });
-			return handleResponse(res, 401, {
+			return handleResponse(res, 400, {
 				message: res.__('you need to login first'),
 			});
 		}

--- a/src/controllers/tests/refreshToken.test.js
+++ b/src/controllers/tests/refreshToken.test.js
@@ -64,7 +64,7 @@ describe('REFRESH', () => {
 				.request(server)
 				.get('/api/v1/accounts/refresh')
 				.end((err, res) => {
-					res.should.have.status(401);
+					res.should.have.status(400);
 					res.body.should.be.a('object');
 					res.body.should.have.property('data');
 					res.body.data.should.have.property('message');
@@ -79,7 +79,7 @@ describe('REFRESH', () => {
 				.get('/api/v1/accounts/refresh')
 				.set('Cookie', 'jwt=bkjfsdkjdfdlsbdshlhjdlhd')
 				.end((err, res) => {
-					res.should.have.status(401);
+					res.should.have.status(400);
 					res.body.should.be.a('object');
 					res.body.should.have.property('data');
 					res.body.data.should.have.property('message');

--- a/src/driverApp/models.js
+++ b/src/driverApp/models.js
@@ -42,6 +42,14 @@ export const DriverSchema = new EntitySchema({
 			type: 'varchar',
 			unique: true,
 		},
+		userId: {
+			nullable: true,
+			type: 'int',
+		},
+		busId: {
+			nullable: true,
+			type: 'int',
+		},
 	},
 	relations: {
 		user: {

--- a/src/driverApp/tests/driver.test.js
+++ b/src/driverApp/tests/driver.test.js
@@ -89,7 +89,7 @@ describe('driver router tests', () => {
 			.to.equal('Samuel');
 		expect(response.body.data)
 			.to.have.property('mobileNumber')
-			.to.equal('0788231378');
+			.to.equal('0788352746');
 	});
 	it('should get all drivers', async () => {
 		const response = await chai


### PR DESCRIPTION
#### What does this PR do?
Fixes the issue of the operator not being able to update the bus details, error status code on return of wrong refresh token and not being able to retrieve the IDs of driver table relations when retrieving drivers. 

#### Description of the tasks to be completed
- [x] The operator should be able to update a bus
- [x] Error message of the wrong refresh token should be 400 instead of 401
- [x] The get driver(s) response object should include the IDs of the driver table relations
- [x] Appropriate error messages are displayed on unsuccessful attempts

#### How should this be manually tested?
**Configure your environment based on the `.env.sample.md` then follow the following:**
```js
git checkout bg-edit-bus-fix-cp-31
git fetch
npm install
// if you don't have postgres installed, refer to the README for instructions
npm start
```
> **Testing the route**
Use the below endpoint
```
POST   /api/v1/accounts/login    //Login
GET   /api/v1/accounts/refresh    //Get the refresh token
PUT   /api/v1/buses/id    //Update a bus
GET   /api/v1/drivers    //Retrive drivers and their details
```
#### Pre-requisites:

- Clone the project
- Make sure that Postgres is up and running

#### What are the relevant trello story:
[#CP-31](https://trello.com/c/rNCacjcA/31-edit-bus-bug-fix)