### PR TITLE
#CP-32 Fix: Class method that update instances

### DIFF
--- a/src/busesApp/controllers.js
+++ b/src/busesApp/controllers.js
@@ -46,8 +46,10 @@ export const putBusHandler = async (req, res) => {
 	const data = matchedData(req, {
 		optional: false,
 	});
-
 	const bus = await updateBus(Bus, id, data);
+	if (bus === null) {
+		return handleResponse(res, 409, { message: res.__('Bus already exists') });
+	}
 	if (!bus)
 		return handleResponse(res, 404, { message: res.__('Bus not found') });
 	return handleResponse(res, 200, res.__('Bus updated'));

--- a/src/busesApp/services.js
+++ b/src/busesApp/services.js
@@ -24,7 +24,13 @@ export const findBuses = async (options = {}) => {
 export const updateBus = async (Model, busId, editInfo) => {
 	const bus = await Model.findOneBy({ id: busId });
 	if (!bus) return false;
-
+	if (
+		editInfo.plateNumber !== undefined &&
+		bus.plateNumber !== editInfo.plateNumber
+	) {
+		const exist = await Model.findByPlate(editInfo.plateNumber);
+		if (exist) return null;
+	}
 	await Model.updateById(bus.id, editInfo);
 	return true;
 };

--- a/src/busesApp/tests/buses.test.js
+++ b/src/busesApp/tests/buses.test.js
@@ -69,6 +69,19 @@ describe('buses router tests', () => {
 		const response = await chai
 			.request(app)
 			.post('/api/v1/buses')
+			.send(data.buses.valid2)
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(201);
+		expect(response.body).to.be.an('object');
+		expect(response.body).to.have.property('status');
+		expect(response.body).to.have.property('code');
+		expect(response.body).to.have.property('data');
+		createdBusId = response.body.data.id;
+	});
+	it('should create a second  new bus', async () => {
+		const response = await chai
+			.request(app)
+			.post('/api/v1/buses')
 			.send(busInfo)
 			.set('Authorization', `Bearer ${token}`);
 		expect(response).to.have.status(201);
@@ -159,6 +172,17 @@ describe('buses router tests', () => {
 		expect(response.body).to.have.property('status');
 		expect(response.body).to.have.property('code');
 		expect(response.body).to.have.property('data');
+	});
+	it('should not update bus update the bus', async () => {
+		const response = await chai
+			.request(app)
+			.put(`/api/v1/buses/${createdBusId}`)
+			.send(data.buses.valid2)
+			.set('Authorization', `Bearer ${token}`);
+		expect(response).to.have.status(409);
+		expect(response.body).to.be.an('object');
+		expect(response.body).to.have.property('status');
+		expect(response.body).to.have.property('code');
 	});
 
 	it('should get all buses', async () => {

--- a/src/models/base.js
+++ b/src/models/base.js
@@ -5,7 +5,11 @@ class CustomBaseEntity extends BaseEntity {
 
 	static async updateById(id, data) {
 		const instance = await this.findOne({ where: { id } });
-		await this.createQueryBuilder().update(instance).set(data).execute();
+		await this.createQueryBuilder()
+			.update(instance)
+			.set(data)
+			.where('id = :id', { id })
+			.execute();
 		const updatedInstance = await this.findOne({ where: { id } });
 		return { updatedInstance };
 	}


### PR DESCRIPTION
Finishes [#CP-32]

### What does this PR do?
- Fix the issue of method updating all instances
- Add a check before updating bus plate plateNumber

### Description of Task to be completed

- [x] Fix the issue of updating all instances
- [x] Update all related tests

### How should this be manually tested?
- Try to change the platenumber to the one existed

```
git clone https://github.com/atlp-rwanda/phantom-be-codebandits
cd phantom-be-codebandits
git fetch origin
git checkout bg-quick-fix-bus-update-32
npm install
//configure the .env according to the .env.sample file
// start the database
npm run dev
// open browser or postman (Check linked public workplace for testing)
```

### Any background context you want to provide?
- Using querybuilder without specifying the necessary matching ID always create a bulk edit 
### What are the relevant pivotal tracker stories?
[#CP-32]

### Screenshots (if appropriate)
